### PR TITLE
fixes bugs with restangular removal in changelogservice.js

### DIFF
--- a/traffic_portal/app/src/common/api/ChangeLogService.js
+++ b/traffic_portal/app/src/common/api/ChangeLogService.js
@@ -22,7 +22,7 @@ var ChangeLogService = function($http, $rootScope, ENV) {
 	this.getNewLogCount = function() {
 		return $http.get(ENV.api['root'] + 'logs/newcount', { ignoreLoadingBar: true }).then(
 			function(result) {
-				return result;
+				return result.data.response;
 			},
 			function(err) {
 				throw err;
@@ -34,7 +34,7 @@ var ChangeLogService = function($http, $rootScope, ENV) {
 		$rootScope.$broadcast('changeLogService::getChangeLogs');
 		return $http.get(ENV.api['root'] + 'logs', {params: queryParams}).then(
 			function(result) {
-				return result;
+				return result.data.response;
 			},
 			function(err) {
 				throw err;

--- a/traffic_portal/app/src/common/models/ChangeLogModel.js
+++ b/traffic_portal/app/src/common/models/ChangeLogModel.js
@@ -41,8 +41,8 @@ var ChangeLogModel = function($rootScope, $interval, changeLogService, userModel
 
 	var getNewLogCount = function() {
 		changeLogService.getNewLogCount()
-			.then(function(result) {
-				newLogCount = result.data.response.newLogcount;
+			.then(function(response) {
+				newLogCount = response.newLogcount;
 			});
 	};
 


### PR DESCRIPTION
getChangeLogs was not working due to wrong object being returned. fixed that and made getNewLogCount consistent.