### PR TITLE
Wrap docker command to build Traffic Ops in JavaScript action

### DIFF
--- a/.github/actions/run-pkg/action.yaml
+++ b/.github/actions/run-pkg/action.yaml
@@ -18,5 +18,5 @@
 name: 'run-pkg'
 description: 'Runs pkg'
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: 'node12'
+  main: 'main.js'

--- a/.github/actions/run-pkg/main.js
+++ b/.github/actions/run-pkg/main.js
@@ -1,0 +1,13 @@
+const GOPATH = '/go',
+    srcDir = `${GOPATH}/src/github.com/apache/trafficcontrol`,
+    component = 'traffic_ops';
+process.exit(
+    require('child_process')
+        .spawnSync('docker', ['run',
+                '-e', `GOPATH=${GOPATH}`,
+                '-v', `${process.env.GITHUB_WORKSPACE}:${srcDir}`,
+                `trafficcontrol/${component}_builder`,
+                `${srcDir}/build/build.sh`, component],
+            {stdio: 'inherit'})
+        .status
+);


### PR DESCRIPTION
This is an example for the `run-pkg` action. It could be generalized to run a wider scope of docker commands. For Traffic Ops + ORT, it takes about 1 minute to complete.

The one downside of JavaScript actions is that, in order to take arguments, it would be necessary to install [the @actions/core NPM package](https://www.npmjs.com/package/@actions/core) (and commit it to the repo, I think). That includes 3MB of NPM dependencies, so it would be necessary to reuse/symlink the `node_modules` directory at the very least or reuse the action in order to cut down on repo size.

Other things to note:

* Adding environment variables to actions in place of inputs is not an option. Even though [`runs.env`](https://help.github.com/en/actions/building-actions/metadata-syntax-for-github-actions#runsenv) is documented for JavaScript actions, [it is not actually supported](https://github.community/t5/GitHub-Actions/Settings-environmental-variables-in-action-s-metadata-does-not/m-p/40719#M4338).
* Putting the GOPATH within `/tmp` does not seem to make the action finish faster.
* Setting the `DOCKER_BUILDKIT` environment variable does not seem to make the action finish faster.